### PR TITLE
Typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A C library for product recommendations/suggestions using collaborative filtering (CF).
 
-Recommender analyzes the the feedback of some users (implicit and explicit) and their 
+Recommender analyzes the feedback of some users (implicit and explicit) and their 
 preferences for some items. It learns patterns and predicts the most suitable products 
 for a particular user.
 


### PR DESCRIPTION
Just deleted an extra 'the' in the README (there was a double 'the').
